### PR TITLE
[CSR-675] Feat/ci timeout pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
-
-
 # [2.0.0-beta.1](https://github.com/currents-dev/cypress-cloud/compare/v2.0.0-beta.0...v2.0.0-beta.1) (2023-09-22)
-
 
 ### Bug Fixes
 
-* debugging fixes ([d502b12](https://github.com/currents-dev/cypress-cloud/commit/d502b121b4a5bb85921fa26b6b04a12274be3b19))
+- debugging fixes ([d502b12](https://github.com/currents-dev/cypress-cloud/commit/d502b121b4a5bb85921fa26b6b04a12274be3b19))
 
 # [2.0.0-beta.0](https://github.com/currents-dev/cypress-cloud/compare/v1.10.0-beta.1...v2.0.0-beta.0) (2023-09-19)
 

--- a/packages/cypress-cloud/bin/lib/program.ts
+++ b/packages/cypress-cloud/bin/lib/program.ts
@@ -129,6 +129,13 @@ ${getLegalNotice()}
       )
         .default(undefined)
         .argParser((i) => (i === "false" ? false : true))
+    ).addOption(
+      new Option(
+        `--ci-timeout-pass [bool]`,
+        `Enable ci runner to pass/fail but no error even if the run timed out`
+      )
+        .default(undefined)
+        .argParser((i) => (i === "false" ? false : true))
     );
 
 export const program = createProgram();

--- a/packages/cypress-cloud/bin/lib/program.ts
+++ b/packages/cypress-cloud/bin/lib/program.ts
@@ -129,7 +129,8 @@ ${getLegalNotice()}
       )
         .default(undefined)
         .argParser((i) => (i === "false" ? false : true))
-    ).addOption(
+    )
+    .addOption(
       new Option(
         `--ci-timeout-pass [bool]`,
         `Enable ci runner to pass/fail but no error even if the run timed out`

--- a/packages/cypress-cloud/lib/api/types/run.ts
+++ b/packages/cypress-cloud/lib/api/types/run.ts
@@ -23,6 +23,7 @@ export type CreateRunPayload = {
   batchSize?: number;
   autoCancelAfterFailures: ValidatedCurrentsParameters["autoCancelAfterFailures"];
   coverageEnabled?: boolean;
+  ciTimeoutPass?: boolean;
 };
 
 export type CloudWarning = {

--- a/packages/cypress-cloud/lib/bootstrap/serializer.ts
+++ b/packages/cypress-cloud/lib/bootstrap/serializer.ts
@@ -66,8 +66,8 @@ function getCypressCLIParams(
   const testingType =
     result.testingType === "component"
       ? {
-        component: true,
-      }
+          component: true,
+        }
       : {};
   return {
     ..._.omit(result, "testingType", "ciTimeoutPass"),

--- a/packages/cypress-cloud/lib/bootstrap/serializer.ts
+++ b/packages/cypress-cloud/lib/bootstrap/serializer.ts
@@ -66,11 +66,11 @@ function getCypressCLIParams(
   const testingType =
     result.testingType === "component"
       ? {
-          component: true,
-        }
+        component: true,
+      }
       : {};
   return {
-    ..._.omit(result, "testingType"),
+    ..._.omit(result, "testingType", "ciTimeoutPass"),
     ...testingType,
   };
 }

--- a/packages/cypress-cloud/lib/run.ts
+++ b/packages/cypress-cloud/lib/run.ts
@@ -64,6 +64,7 @@ export async function run(params: CurrentsRunParameters = {}) {
     batchSize,
     autoCancelAfterFailures,
     experimentalCoverageRecording,
+    ciTimeoutPass
   } = validatedParams;
 
   const config = await getMergedConfig(validatedParams);
@@ -87,8 +88,7 @@ export async function run(params: CurrentsRunParameters = {}) {
   info(`Cypress version: ${dim(_cypressVersion)}`);
   info("Discovered %d spec files", specs.length);
   info(
-    `Tags: ${tag.length > 0 ? tag.join(",") : false}; Group: ${
-      group ?? false
+    `Tags: ${tag.length > 0 ? tag.join(",") : false}; Group: ${group ?? false
     }; Parallel: ${parallel ?? false}; Batch Size: ${batchSize}`
   );
   info("Connecting to cloud orchestration service...");
@@ -109,6 +109,7 @@ export async function run(params: CurrentsRunParameters = {}) {
     batchSize,
     autoCancelAfterFailures,
     coverageEnabled: experimentalCoverageRecording,
+    ciTimeoutPass
   });
 
   setRunId(run.runId);

--- a/packages/cypress-cloud/lib/run.ts
+++ b/packages/cypress-cloud/lib/run.ts
@@ -64,7 +64,7 @@ export async function run(params: CurrentsRunParameters = {}) {
     batchSize,
     autoCancelAfterFailures,
     experimentalCoverageRecording,
-    ciTimeoutPass
+    ciTimeoutPass,
   } = validatedParams;
 
   const config = await getMergedConfig(validatedParams);
@@ -88,7 +88,8 @@ export async function run(params: CurrentsRunParameters = {}) {
   info(`Cypress version: ${dim(_cypressVersion)}`);
   info("Discovered %d spec files", specs.length);
   info(
-    `Tags: ${tag.length > 0 ? tag.join(",") : false}; Group: ${group ?? false
+    `Tags: ${tag.length > 0 ? tag.join(",") : false}; Group: ${
+      group ?? false
     }; Parallel: ${parallel ?? false}; Batch Size: ${batchSize}`
   );
   info("Connecting to cloud orchestration service...");
@@ -109,7 +110,7 @@ export async function run(params: CurrentsRunParameters = {}) {
     batchSize,
     autoCancelAfterFailures,
     coverageEnabled: experimentalCoverageRecording,
-    ciTimeoutPass
+    ciTimeoutPass,
   });
 
   setRunId(run.runId);

--- a/packages/cypress-cloud/types.ts
+++ b/packages/cypress-cloud/types.ts
@@ -173,11 +173,16 @@ export type CurrentsRunParameters = StrippedCypressModuleAPIOptions & {
    * Whether to record coverage results. If set, must be a boolean, defaults to false.
    */
   experimentalCoverageRecording?: boolean;
+
+  /**
+   * Flag to allow a github action to pass/fail but no error, if the run is timed out.
+   */
+  ciTimeoutPass?: boolean;
 };
 
 // User-facing `run` interface
 // We can resolve the projectId and recordKey from different sources, so we can't really enforce them via the type definition
-export interface CurrentsRunAPI extends CurrentsRunParameters {}
+export interface CurrentsRunAPI extends CurrentsRunParameters { }
 
 // Params after validation and resolution
 export interface ValidatedCurrentsParameters extends CurrentsRunParameters {

--- a/packages/cypress-cloud/types.ts
+++ b/packages/cypress-cloud/types.ts
@@ -182,7 +182,7 @@ export type CurrentsRunParameters = StrippedCypressModuleAPIOptions & {
 
 // User-facing `run` interface
 // We can resolve the projectId and recordKey from different sources, so we can't really enforce them via the type definition
-export interface CurrentsRunAPI extends CurrentsRunParameters { }
+export interface CurrentsRunAPI extends CurrentsRunParameters {}
 
 // Params after validation and resolution
 export interface ValidatedCurrentsParameters extends CurrentsRunParameters {


### PR DESCRIPTION
This adds support for `ci-timeout-pass` flag that allows a run to don't fail on a GitHub action if the run times out. Instead it will pass/fail according to the tests.

https://www.loom.com/share/4deaa48185554803852382ac93cc99ca?sid=c93068d9-a904-4630-8436-38044a5dacf2